### PR TITLE
docs: correct HACS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aha region
 [![CI](https://github.com/flabbamann/aha_region/actions/workflows/ci.yaml/badge.svg)](https://github.com/flabbamann/aha_region/actions/workflows/ci.yaml)
-[![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=flabbamann&repository=https%3A%2F%2Fgithub.com%2Fflabbamann%2Faha_region&category=integration)
+[![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=flabbamann&repository=aha_region&category=integration)
 
 Home Assistant custom component for aha (Zweckverband Abfallwirtschaft Region Hannover). This integration provides the next collection date per waste type for a given address as date-sensors.
 


### PR DESCRIPTION
the current url leads to an error since the `repository` field should only contain the name of the repo and not the whole URL

<img width="629" alt="image" src="https://user-images.githubusercontent.com/17279485/213583425-6bd7fd9b-040c-408a-9899-196cc2a988f0.png">
