### PR TITLE
Config schema

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/custom_components/aha_region/__init__.py
+++ b/custom_components/aha_region/__init__.py
@@ -1,6 +1,11 @@
 """aha custom component."""
 
 from homeassistant import core
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN
+
+CONFIG_SCHEMA = cv.platform_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 black==23.9.1
-homeassistant
+homeassistant>=2023.7.0
 mypy==1.6.0
 pre-commit==3.5.0
 pytest==7.4.2


### PR DESCRIPTION
Define CONFIG_SCHEMA, to fix a hassfest validation warning.

This requires Home Assistant >= 2023.7.0 which requires at least Python 3.10
